### PR TITLE
Connect via IP, not DNS

### DIFF
--- a/ecsctl/pty.py
+++ b/ecsctl/pty.py
@@ -28,7 +28,7 @@ class Pty:
         )
         ec2_instance_id = node_info['ec2InstanceId']
         ec2_info = self.bw.describe_instance(ec2_instance_id)
-        return first_container_name, ec2_info['PrivateDnsName']
+        return first_container_name, ec2_info['PrivateIpAddress']
 
     def find_container_id(self, client, container_name):
         containers = client.containers()


### PR DESCRIPTION
I think it's better to connect via IP not private DNS, cuz then you have to setup system for resolving AWS internal DNS names from your laptop. But with IP address any VPN connection would work without any trouble.